### PR TITLE
Log tests if they are slower than 2ms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test
+
+test:
+	TZ=GMT mocha --bail --slow 2
+
+install:
+	npm install

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
 machine:
   node: 
     version: 0.10.30
+
+test:
+  override:
+    - make test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails",
-  "author": "Mike McNeil <mike@balderdash.co>",
+  "author": "Shyp Engineering <engineering@shyp.com>",
   "version": "0.10.5",
   "description": "API-driven framework for building realtime apps, using MVC conventions (based on Express and Socket.io)",
   "homepage": "http://sailsjs.org",


### PR DESCRIPTION
Add a very basic Makefile and tell CircleCI to use the Makefile instead of
running `npm test`.
