### PR TITLE
Only shrinkwrap prod dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,13 @@ test:
 
 install:
 	npm install
+
+shrinkwrap:
+	rm -rf node_modules
+	rm -rf npm-shrinkwrap.json
+	npm cache clear
+	npm install --production
+	npm shrinkwrap
+	npm install --production
+	npm shrinkwrap
+	clingwrap npmbegone

--- a/README.md
+++ b/README.md
@@ -50,10 +50,6 @@ $ cd testProject
 $ sails lift
 ```
 
-**Generate a REST API:**
-
-[![ScreenShot](http://i.imgur.com/Ii88jlhl.png)](https://www.youtube.com/watch?v=GK-tFvpIR7c)
-
 
 ## Compatibility
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "sails",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "dependencies": {
     "anchor": {
       "version": "0.10.2",
@@ -14,15 +14,9 @@
     "async": {
       "version": "0.2.10"
     },
-    "benchmark": {
-      "version": "1.0.0"
-    },
     "captains-log": {
       "version": "0.11.11",
       "dependencies": {
-        "lodash": {
-          "version": "2.4.1"
-        },
         "rc": {
           "version": "0.3.5",
           "dependencies": {
@@ -36,27 +30,6 @@
               "version": "1.1.0"
             }
           }
-        }
-      }
-    },
-    "checksum": {
-      "version": "0.1.1",
-      "dependencies": {
-        "optimist": {
-          "version": "0.3.7",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3"
-            }
-          }
-        }
-      }
-    },
-    "coffee-script": {
-      "version": "1.7.1",
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.3.5"
         }
       }
     },
@@ -74,9 +47,6 @@
     },
     "ejs-locals": {
       "version": "1.0.2"
-    },
-    "expect.js": {
-      "version": "0.2.0"
     },
     "express": {
       "version": "3.4.3",
@@ -109,7 +79,7 @@
                   "version": "1.1.13",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1"
+                      "version": "1.0.2"
                     },
                     "isarray": {
                       "version": "0.0.1"
@@ -156,10 +126,23 @@
           "version": "0.0.1"
         },
         "send": {
-          "version": "0.1.4"
+          "version": "0.1.4",
+          "dependencies": {
+            "mime": {
+              "version": "1.2.11"
+            }
+          }
         },
         "cookie-signature": {
           "version": "1.0.1"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1"
+            }
+          }
         }
       }
     },
@@ -275,10 +258,10 @@
           "version": "0.3.0",
           "dependencies": {
             "lru-cache": {
-              "version": "2.5.2"
+              "version": "2.7.3"
             },
             "sigmund": {
-              "version": "1.0.0"
+              "version": "1.0.1"
             }
           }
         }
@@ -291,7 +274,7 @@
           "version": "0.1.5"
         },
         "mustache": {
-          "version": "2.0.0"
+          "version": "2.2.1"
         },
         "debug": {
           "version": "2.2.0",
@@ -311,360 +294,11 @@
         }
       }
     },
-    "istanbul": {
-      "version": "0.4.1",
-      "dependencies": {
-        "abbrev": {
-          "version": "1.0.7"
-        },
-        "async": {
-          "version": "1.5.0"
-        },
-        "escodegen": {
-          "version": "1.7.1",
-          "dependencies": {
-            "estraverse": {
-              "version": "1.9.3"
-            },
-            "esutils": {
-              "version": "2.0.2"
-            },
-            "esprima": {
-              "version": "1.2.5"
-            },
-            "optionator": {
-              "version": "0.5.0",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2"
-                },
-                "deep-is": {
-                  "version": "0.1.3"
-                },
-                "wordwrap": {
-                  "version": "0.0.3"
-                },
-                "type-check": {
-                  "version": "0.3.1"
-                },
-                "levn": {
-                  "version": "0.2.5"
-                },
-                "fast-levenshtein": {
-                  "version": "1.0.7"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.2.0",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "esprima": {
-          "version": "2.7.1"
-        },
-        "fileset": {
-          "version": "0.2.1",
-          "dependencies": {
-            "minimatch": {
-              "version": "2.0.10",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.2",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.3.0"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1"
-                    }
-                  }
-                }
-              }
-            },
-            "glob": {
-              "version": "5.0.15",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0"
-                }
-              }
-            }
-          }
-        },
-        "handlebars": {
-          "version": "4.0.5",
-          "dependencies": {
-            "optimist": {
-              "version": "0.6.1",
-              "dependencies": {
-                "wordwrap": {
-                  "version": "0.0.3"
-                },
-                "minimist": {
-                  "version": "0.0.10"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.0"
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.6.1",
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10"
-                },
-                "source-map": {
-                  "version": "0.5.3"
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2"
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1"
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.2",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.3",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "2.0.1",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.0"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.2"
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "0.2.7"
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.3",
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "2.0.1",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.0"
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1"
-                                },
-                                "repeat-string": {
-                                  "version": "1.5.2"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2"
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.1.2",
-                      "dependencies": {
-                        "escape-string-regexp": {
-                          "version": "1.0.4"
-                        }
-                      }
-                    },
-                    "window-size": {
-                      "version": "0.1.0"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "3.4.6",
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.3",
-              "dependencies": {
-                "lodash": {
-                  "version": "3.10.1"
-                },
-                "sprintf-js": {
-                  "version": "1.0.3"
-                }
-              }
-            },
-            "inherit": {
-              "version": "2.2.2"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8"
-            }
-          }
-        },
-        "nopt": {
-          "version": "3.0.6"
-        },
-        "once": {
-          "version": "1.3.3",
-          "dependencies": {
-            "wrappy": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "resolve": {
-          "version": "1.1.6"
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "which": {
-          "version": "1.2.1",
-          "dependencies": {
-            "is-absolute": {
-              "version": "0.1.7",
-              "dependencies": {
-                "is-relative": {
-                  "version": "0.1.3"
-                }
-              }
-            }
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0"
-        }
-      }
-    },
     "lodash": {
-      "version": "2.4.2"
+      "version": "2.4.1"
     },
     "merge-defaults": {
       "version": "0.1.4"
-    },
-    "microtime": {
-      "version": "0.6.0",
-      "dependencies": {
-        "bindings": {
-          "version": "1.2.0"
-        },
-        "nan": {
-          "version": "1.0.0"
-        }
-      }
-    },
-    "mocha": {
-      "version": "1.17.1",
-      "dependencies": {
-        "commander": {
-          "version": "2.0.0"
-        },
-        "growl": {
-          "version": "1.7.0"
-        },
-        "jade": {
-          "version": "0.26.3",
-          "dependencies": {
-            "commander": {
-              "version": "0.6.1"
-            },
-            "mkdirp": {
-              "version": "0.3.0"
-            }
-          }
-        },
-        "diff": {
-          "version": "1.0.7"
-        },
-        "debug": {
-          "version": "2.2.0",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.1"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.3.5"
-        },
-        "glob": {
-          "version": "3.2.3",
-          "dependencies": {
-            "minimatch": {
-              "version": "0.2.14",
-              "dependencies": {
-                "lru-cache": {
-                  "version": "2.7.3"
-                },
-                "sigmund": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "2.0.3"
-            },
-            "inherits": {
-              "version": "2.0.1"
-            }
-          }
-        }
-      }
     },
     "mock-req": {
       "version": "0.1.0"
@@ -677,14 +311,6 @@
     },
     "pluralize": {
       "version": "0.0.12"
-    },
-    "portfinder": {
-      "version": "0.2.1",
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.0.7"
-        }
-      }
     },
     "prompt": {
       "version": "0.2.14",
@@ -805,7 +431,7 @@
           "version": "0.1.3"
         },
         "ini": {
-          "version": "1.3.3"
+          "version": "1.3.4"
         }
       }
     },
@@ -814,250 +440,6 @@
       "dependencies": {
         "node-switchback": {
           "version": "0.0.4"
-        }
-      }
-    },
-    "request": {
-      "version": "2.67.0",
-      "dependencies": {
-        "bl": {
-          "version": "1.0.0",
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.5",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2"
-                },
-                "inherits": {
-                  "version": "2.0.1"
-                },
-                "isarray": {
-                  "version": "0.0.1"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.6"
-                },
-                "string_decoder": {
-                  "version": "0.10.31"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2"
-                }
-              }
-            }
-          }
-        },
-        "caseless": {
-          "version": "0.11.0"
-        },
-        "extend": {
-          "version": "3.0.0"
-        },
-        "forever-agent": {
-          "version": "0.6.1"
-        },
-        "form-data": {
-          "version": "1.0.0-rc3",
-          "dependencies": {
-            "async": {
-              "version": "1.5.0"
-            }
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1"
-        },
-        "mime-types": {
-          "version": "2.1.8",
-          "dependencies": {
-            "mime-db": {
-              "version": "1.20.0"
-            }
-          }
-        },
-        "qs": {
-          "version": "5.2.0"
-        },
-        "tunnel-agent": {
-          "version": "0.4.2"
-        },
-        "tough-cookie": {
-          "version": "2.2.1"
-        },
-        "http-signature": {
-          "version": "1.1.0",
-          "dependencies": {
-            "assert-plus": {
-              "version": "0.1.5"
-            },
-            "jsprim": {
-              "version": "1.2.2",
-              "dependencies": {
-                "extsprintf": {
-                  "version": "1.0.2"
-                },
-                "json-schema": {
-                  "version": "0.2.2"
-                },
-                "verror": {
-                  "version": "1.3.6"
-                }
-              }
-            },
-            "sshpk": {
-              "version": "1.7.1",
-              "dependencies": {
-                "asn1": {
-                  "version": "0.2.3"
-                },
-                "assert-plus": {
-                  "version": "0.2.0"
-                },
-                "dashdash": {
-                  "version": "1.10.1",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5"
-                    }
-                  }
-                },
-                "jsbn": {
-                  "version": "0.1.0"
-                },
-                "tweetnacl": {
-                  "version": "0.13.2"
-                },
-                "jodid25519": {
-                  "version": "1.0.2"
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1"
-                }
-              }
-            }
-          }
-        },
-        "oauth-sign": {
-          "version": "0.8.0"
-        },
-        "hawk": {
-          "version": "3.1.2",
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3"
-            },
-            "boom": {
-              "version": "2.10.1"
-            },
-            "cryptiles": {
-              "version": "2.0.5"
-            },
-            "sntp": {
-              "version": "1.0.9"
-            }
-          }
-        },
-        "aws-sign2": {
-          "version": "0.6.0"
-        },
-        "stringstream": {
-          "version": "0.0.5"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "dependencies": {
-            "delayed-stream": {
-              "version": "1.0.0"
-            }
-          }
-        },
-        "isstream": {
-          "version": "0.1.2"
-        },
-        "is-typedarray": {
-          "version": "1.0.0"
-        },
-        "har-validator": {
-          "version": "2.0.3",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.1",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.1.0"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.4"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0"
-                }
-              }
-            },
-            "commander": {
-              "version": "2.9.0",
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1"
-                }
-              }
-            },
-            "is-my-json-valid": {
-              "version": "2.12.3",
-              "dependencies": {
-                "generate-function": {
-                  "version": "2.0.0"
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "dependencies": {
-                    "is-property": {
-                      "version": "1.0.2"
-                    }
-                  }
-                },
-                "jsonpointer": {
-                  "version": "2.0.0"
-                },
-                "xtend": {
-                  "version": "4.0.1"
-                }
-              }
-            },
-            "pinkie-promise": {
-              "version": "2.0.0",
-              "dependencies": {
-                "pinkie": {
-                  "version": "2.0.1"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "root-require": {
-      "version": "0.2.0",
-      "dependencies": {
-        "packpath": {
-          "version": "0.1.0"
         }
       }
     },
@@ -1086,43 +468,6 @@
     "sails-generate": {
       "version": "0.11.6",
       "dependencies": {
-        "sails-generate-adapter": {
-          "version": "0.10.5"
-        },
-        "sails-generate-api": {
-          "version": "0.10.0"
-        },
-        "sails-generate-backend": {
-          "version": "0.11.3"
-        },
-        "sails-generate-controller": {
-          "version": "0.10.8",
-          "dependencies": {
-            "pluralize": {
-              "version": "0.0.9"
-            },
-            "underscore.string": {
-              "version": "2.3.3"
-            }
-          }
-        },
-        "sails-generate-frontend": {
-          "version": "0.10.20"
-        },
-        "sails-generate-generator": {
-          "version": "0.10.11"
-        },
-        "sails-generate-gruntfile": {
-          "version": "0.10.10"
-        },
-        "sails-generate-model": {
-          "version": "0.10.10",
-          "dependencies": {
-            "underscore.string": {
-              "version": "2.3.3"
-            }
-          }
-        },
         "sails-generate-new": {
           "version": "0.10.22",
           "dependencies": {
@@ -1145,8 +490,45 @@
             }
           }
         },
+        "sails-generate-backend": {
+          "version": "0.11.3"
+        },
+        "sails-generate-frontend": {
+          "version": "0.10.20"
+        },
+        "sails-generate-gruntfile": {
+          "version": "0.10.10"
+        },
+        "sails-generate-api": {
+          "version": "0.10.0"
+        },
+        "sails-generate-model": {
+          "version": "0.10.10",
+          "dependencies": {
+            "underscore.string": {
+              "version": "2.3.3"
+            }
+          }
+        },
+        "sails-generate-controller": {
+          "version": "0.10.8",
+          "dependencies": {
+            "underscore.string": {
+              "version": "2.3.3"
+            },
+            "pluralize": {
+              "version": "0.0.9"
+            }
+          }
+        },
         "sails-generate-views": {
           "version": "0.10.5"
+        },
+        "sails-generate-adapter": {
+          "version": "0.10.5"
+        },
+        "sails-generate-generator": {
+          "version": "0.10.11"
         },
         "sails-generate-views-jade": {
           "version": "0.10.3"
@@ -1157,35 +539,32 @@
       "version": "0.3.2"
     },
     "sails-util": {
-      "version": "0.10.4",
+      "version": "0.10.6",
       "dependencies": {
         "json-stringify-safe": {
           "version": "5.0.1"
         },
-        "node-switchback": {
-          "version": "0.0.2"
+        "underscore.string": {
+          "version": "2.3.3"
         },
         "optimist": {
           "version": "0.6.1",
           "dependencies": {
-            "minimist": {
-              "version": "0.0.10"
-            },
             "wordwrap": {
               "version": "0.0.3"
+            },
+            "minimist": {
+              "version": "0.0.10"
             }
           }
         },
-        "underscore.string": {
-          "version": "2.3.3"
+        "switchback": {
+          "version": "1.1.3"
         }
       }
     },
     "semver": {
       "version": "2.2.1"
-    },
-    "should": {
-      "version": "2.1.1"
     },
     "skipper": {
       "version": "0.5.8",
@@ -1593,76 +972,6 @@
         }
       }
     },
-    "socket.io-client": {
-      "version": "0.9.17",
-      "dependencies": {
-        "uglify-js": {
-          "version": "1.2.5"
-        },
-        "ws": {
-          "version": "0.4.32",
-          "dependencies": {
-            "nan": {
-              "version": "1.0.0"
-            },
-            "tinycolor": {
-              "version": "0.0.1"
-            },
-            "options": {
-              "version": "0.0.6"
-            }
-          }
-        },
-        "xmlhttprequest": {
-          "version": "1.4.2"
-        },
-        "active-x-obfuscator": {
-          "version": "0.0.1",
-          "dependencies": {
-            "zeparser": {
-              "version": "0.0.5"
-            }
-          }
-        }
-      }
-    },
-    "supertest": {
-      "version": "0.8.3",
-      "dependencies": {
-        "superagent": {
-          "version": "0.16.0",
-          "dependencies": {
-            "qs": {
-              "version": "0.6.5"
-            },
-            "formidable": {
-              "version": "1.0.14"
-            },
-            "mime": {
-              "version": "1.2.5"
-            },
-            "emitter-component": {
-              "version": "1.0.0"
-            },
-            "methods": {
-              "version": "0.0.1"
-            },
-            "cookiejar": {
-              "version": "1.3.0"
-            },
-            "debug": {
-              "version": "0.7.4"
-            },
-            "reduce-component": {
-              "version": "1.0.1"
-            }
-          }
-        },
-        "methods": {
-          "version": "0.1.0"
-        }
-      }
-    },
     "waterline": {
       "version": "1.0.0",
       "resolved": "git+https://github.com/Shyp/waterline.git#b8a50abc85f963afeda47aef1da18ad78f25afd8",
@@ -1687,22 +996,6 @@
           "dependencies": {
             "lodash": {
               "version": "3.10.1"
-            }
-          }
-        }
-      }
-    },
-    "wrench": {
-      "version": "1.5.8"
-    },
-    "clingwrap": {
-      "version": "1.1.0",
-      "dependencies": {
-        "cli-table": {
-          "version": "0.3.1",
-          "dependencies": {
-            "colors": {
-              "version": "1.0.3"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "pluralize": "~0.0.5",
     "prompt": "~0.2.13",
     "rc": "~0.5.0",
-    "reportback": "^0.1.8",
+    "reportback": "0.1.8",
     "sails-build-dictionary": "~0.10.1",
     "sails-disk": "~0.10.0",
     "sails-generate": "^0.11.6",


### PR DESCRIPTION
Otherwise when we try to npm install sails into the Shyp API repo it complains
about the extraneous dev dependencies, which we don't want in the API project.
