### PR TITLE
Change the default port from 1337

### DIFF
--- a/lib/hooks/http/index.js
+++ b/lib/hooks/http/index.js
@@ -29,7 +29,7 @@ module.exports = function(sails) {
         // host: 'localhost',
 
         // Port to run this app on
-        port: 1337,
+        port: 6789,
 
         // Users' SSL cert settings end up here
         ssl: {},

--- a/lib/hooks/sockets/lib/index.js
+++ b/lib/hooks/sockets/lib/index.js
@@ -21,7 +21,7 @@ module.exports = function(sails) {
       // host: 'localhost',
 
       // Port to run this app on
-      port: 1337,
+      port: 6789,
 
       // Users' SSL cert settings end up here
       ssl: {},

--- a/test/hooks/request/req.metadata.test.js
+++ b/test/hooks/request/req.metadata.test.js
@@ -50,9 +50,9 @@ describe('Request hook', function () {
       it('should add a port to baseUrl on a custom port', function() {
         this.req.protocol = 'http';
         this.req.host = 'example.org';
-        this.req.headers.Host = 'example.org:1337';
+        this.req.headers.Host = 'example.org:6789';
         mixinMetadata(this.req);
-        assert.equal(this.req.baseUrl, 'http://example.org:1337');
+        assert.equal(this.req.baseUrl, 'http://example.org:6789');
       });
 
       it('should handle running as HTTP on port 443', function() {


### PR DESCRIPTION
1337 is "leet", which is pretty juvenile; see the Urban
Dictionary page for more info. Change it to 6789. Per
https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers, nothing
noteworthy is running on that port.
