### PR TITLE
Upgrade Waterline to 1.0.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -937,14 +937,23 @@
       }
     },
     "waterline": {
-      "version": "1.0.0",
-      "resolved": "git+https://github.com/Shyp/waterline.git#b8a50abc85f963afeda47aef1da18ad78f25afd8",
+      "version": "1.0.1",
+      "resolved": "git+https://github.com/Shyp/waterline.git#62c43160986db5547ac56093ba30c3727364a429",
       "dependencies": {
+        "anchor": {
+          "version": "0.10.2",
+          "resolved": "git://github.com/Shyp/anchor.git#6c0c1edc1c88af857336b014a4508d93a8b33bf5",
+          "dependencies": {
+            "validator": {
+              "version": "3.22.2"
+            }
+          }
+        },
         "async": {
-          "version": "0.9.2"
+          "version": "0.9.0"
         },
         "bluebird": {
-          "version": "2.10.2"
+          "version": "2.9.24"
         },
         "deep-diff": {
           "version": "0.1.7"
@@ -953,15 +962,11 @@
           "version": "0.1.2"
         },
         "waterline-criteria": {
-          "version": "0.11.2"
+          "version": "0.11.1"
         },
         "waterline-schema": {
-          "version": "0.1.19",
-          "dependencies": {
-            "lodash": {
-              "version": "3.10.1"
-            }
-          }
+          "version": "0.1.17",
+          "resolved": "git://github.com/Shyp/waterline-schema.git#2c228532f3d480b6dc2bfdd5911d10015abc515d"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "semver": "~2.2.1",
     "skipper": "~0.5.3",
     "socket.io": "~0.9.14",
-    "waterline": "git+https://github.com/Shyp/waterline.git#shyp-master-1.0.0"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v1.0.1"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",


### PR DESCRIPTION
This makes the npm-shrinkwrap for Waterline match up with the npm-shrinkwrap
that's in the Shyp API, since we're now installing the Waterline dependencies
via Waterline's shrinkwrap file.
