### PR TITLE
Update Waterline to 1.1.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -787,8 +787,8 @@
       }
     },
     "waterline": {
-      "version": "1.0.1",
-      "resolved": "git+https://github.com/Shyp/waterline.git#62c43160986db5547ac56093ba30c3727364a429",
+      "version": "1.1.0",
+      "resolved": "git+https://github.com/Shyp/waterline.git#7e5421f31305581c4779540ca28c431c19130452",
       "dependencies": {
         "anchor": {
           "version": "0.10.2",
@@ -815,8 +815,8 @@
           "version": "0.11.1"
         },
         "waterline-schema": {
-          "version": "0.1.17",
-          "resolved": "git://github.com/Shyp/waterline-schema.git#2c228532f3d480b6dc2bfdd5911d10015abc515d"
+          "version": "0.2.0",
+          "resolved": "git://github.com/Shyp/waterline-schema.git#d1a33deea5fe67bff40934e962f4aff4d11b671a"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sails-util": "^0.10.4",
     "semver": "~2.2.1",
     "skipper": "~0.5.3",
-    "waterline": "git+https://github.com/Shyp/waterline.git#v1.0.1"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v1.1.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",

--- a/test/integration/fixtures/sampleapp/config/env/testmysql.js
+++ b/test/integration/fixtures/sampleapp/config/env/testmysql.js
@@ -19,6 +19,6 @@ module.exports = {
   },
   models: {
     connection: 'mysql',
-    migrate: 'alter'
+    migrate: 'safe'
   }
 };

--- a/test/integration/fixtures/sampleapp/config/local.js
+++ b/test/integration/fixtures/sampleapp/config/local.js
@@ -11,6 +11,6 @@ module.exports = {
     defaultLimit: 10
   },
   models: {
-    migrate: 'alter'
+    migrate: 'safe'
   }
 };


### PR DESCRIPTION
The primary change here is to remove the 'alter' migration strategy from
Waterline. In addition, we remove a lot of code related to dynamic finders and
association finders, both of which we don't use.

Diff is here: https://github.com/shyp/waterline/compare/v1.0.1...v1.1.0

In addition we upgraded waterline-schema to 0.2.0, to remove 'alter' as the
default migration strategy.

https://github.com/shyp/waterline-schema/compare/shyp-master-0.1.17...v0.2.0
