### PR TITLE
Fix npm at version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "istanbul": "*",
     "microtime": "~0.6.0",
     "mocha": "2.3.4",
+    "npm": "2",
     "portfinder": "~0.2.1",
     "request": "*",
     "root-require": "~0.2.0",


### PR DESCRIPTION
It prevents clingwrap from attempting to install npm 3 (which we don't want)
and also quiets a warning when `npm install`ing Sails.
