### PR TITLE
Remove connect-flash dependency

### DIFF
--- a/lib/hooks/request/README.md
+++ b/lib/hooks/request/README.md
@@ -17,10 +17,6 @@ This hook's responsibilities are:
 + req.port
 + req._sails (access to the app's `sails` object in case it's not global)
 
-##### Flash Middleware
-+ req.flash('keyToGet')
-+ req.flash('keyToSet','valueToSetOnKey')
-
 ##### Set default view locals (i.e. `app.locals`)
 + `_` (lodash)
 + `session`

--- a/lib/hooks/request/index.js
+++ b/lib/hooks/request/index.js
@@ -82,32 +82,25 @@ module.exports = function(sails) {
       before: {
         'all /*': function addMixins (req, res, next) {
 
-          // Run connect-flash middleware to support flash messages
-          // TODO: potential optimization-- pull this out so it only runs once
-          var flashMiddleware = (require('connect-flash')());
-          flashMiddleware(req, res, function(err) {
-            if (err) return next(err);
+          // Provide access to `sails` object
+          req._sails = req._sails || sails;
 
-            // Provide access to `sails` object
-            req._sails = req._sails || sails;
+          // Add a few `res.locals` by default
+          _mixinLocals(req, res);
 
-            // Add a few `res.locals` by default
-            _mixinLocals(req, res);
+          // Add information about the server to the request context
+          _mixinServerMetadata(req, res);
 
-            // Add information about the server to the request context
-            _mixinServerMetadata(req, res);
+          // Add `req.validate()` method
+          _mixinReqValidate(req, res);
 
-            // Add `req.validate()` method
-            _mixinReqValidate(req, res);
+          // Only apply HTTP-focused middleware if it makes sense
+          // (i.e. if this is an HTTP request)
+          if (req.protocol === 'http' || req.protocol === 'https') {
+            _mixinReqQualifiers(req, res);
+          }
 
-            // Only apply HTTP-focused middleware if it makes sense
-            // (i.e. if this is an HTTP request)
-            if (req.protocol === 'http' || req.protocol === 'https') {
-              _mixinReqQualifiers(req, res);
-            }
-
-            next();
-          });
+          next();
         }
       }
 

--- a/lib/hooks/request/validate.js
+++ b/lib/hooks/request/validate.js
@@ -45,7 +45,6 @@ module.exports = function (req, res) {
       });
 
       if (redirectTo) {
-        req.flash('error', e);
         res.redirect(redirectTo);
       }
       else {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -30,9 +30,6 @@
     "commander": {
       "version": "2.1.0"
     },
-    "connect-flash": {
-      "version": "0.1.1"
-    },
     "debug": {
       "version": "2.2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "captains-log": "0.11.11",
     "colors": "0.6.2",
     "commander": "2.1.0",
-    "connect-flash": "0.1.1",
     "debug": "2.2.0",
     "ejs": "0.8.8",
     "ejs-locals": "1.0.2",

--- a/test/hooks/request/req.validate.test.js
+++ b/test/hooks/request/req.validate.test.js
@@ -67,31 +67,6 @@ describe('Request hook', function (){
       sails.request(ROUTEADDRESS+'?foo=hi');
     });
 
-    it('should redirect and use req.flash to store error in session if `redirectTo` is specified', function (done) {
-      var ROUTEADDRESS = '/req_validate2';
-      var fakeSession = {};
-      sails.router.bind(ROUTEADDRESS, function (req, res, next) {
-        req.validate({
-          bar: 'string'
-        }, '/somewhereElse');
-        return res.send(200);
-      })
-      .emit('router:request', {
-        url: ROUTEADDRESS,
-        query: {
-          foo: 'hi'
-        },
-        session: fakeSession
-      }, {
-        redirect: function fakeRedirect (dest) {
-          assert(dest === '/somewhereElse');
-          assert(fakeSession.flash.error);
-          return done();
-        }
-      });
-    });
-
-
     it('should support nested usage', function (done) {
       var ROUTEADDRESS = 'POST /req_validate3';
       sails.router.bind(ROUTEADDRESS, function (req, res, next) {


### PR DESCRIPTION
It's used to display flash messages via `req.flash('some message')` but our API
has no use for flash messages, so it's safe to remove this, the callback, and
the one place where Sails attempts to flash a message.
