### PR TITLE
Upgrade Waterline to Shyp/1.3.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -787,8 +787,8 @@
       }
     },
     "waterline": {
-      "version": "1.1.0",
-      "resolved": "git+https://github.com/Shyp/waterline.git#7e5421f31305581c4779540ca28c431c19130452",
+      "version": "1.3.0",
+      "resolved": "git+https://github.com/Shyp/waterline.git#596ae15e45c00caed3f422681d1d0ef0b16b9760",
       "dependencies": {
         "anchor": {
           "version": "0.10.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sails-util": "^0.10.4",
     "semver": "~2.2.1",
     "skipper": "~0.5.3",
-    "waterline": "git+https://github.com/Shyp/waterline.git#v1.1.0"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v1.3.0"
   },
   "devDependencies": {
     "benchmark": "~1.0.0",


### PR DESCRIPTION
This update fixes the error where `create([item1, item2])` would occasionally
return results out of order. Finally results will be returned in the same error
that you create them!

Also removes support for `findOrCreate` and `findOrCreateEach`, the
`afterValidate` lifecycle callback, and the `afterCreate` lifecycle callback.

https://github.com/shyp/waterline/compare/v1.1.0...v1.3.0
