### PR TITLE
Disable methodOverride

### DIFF
--- a/lib/hooks/http/index.js
+++ b/lib/hooks/http/index.js
@@ -59,7 +59,6 @@ module.exports = function(sails) {
               'bodyParser',
               'handleBodyParserError',
               'compress',
-              'methodOverride',
               'poweredBy',
               '$custom',
               'router',
@@ -113,27 +112,7 @@ module.exports = function(sails) {
           // Example override:
           // cookieParser: (function cookieParser (req, res, next) {})(),
           cookieParser: express.cookieParser,
-
-
-
-          // HTTP method override middleware
-          //      (or false to disable)
-          //
-          // This option allows artificial query params to be passed to trick
-          // Express into thinking a different HTTP verb was used.
-          // Useful when supporting an API for user-agents which don't allow
-          // PUT or DELETE requests
-          //
-          // Defaults to `express.methodOverride`
-          //
-          // Example override:
-          // methodOverride: (function customMethodOverride (req, res, next) {})()
-          methodOverride: express.methodOverride
-
-
         }
-
-
       };
     },
 

--- a/lib/hooks/http/middleware/defaults.js
+++ b/lib/hooks/http/middleware/defaults.js
@@ -156,15 +156,6 @@ module.exports = function(sails, app) {
       return res.send(400, bodyParserFailureErrorMsg);
     },
 
-
-    // Allow simulation of PUT and DELETE HTTP methods for user agents
-    // which don't support it natively (looks for a `_method` param)
-    methodOverride: (function() {
-      if (sails.config.http.methodOverride) {
-        return sails.config.http.methodOverride();
-      }
-    })(),
-
     // By default, the express router middleware is installed towards the end.
     // This is so that all the built-in core Express/Connect middleware
     // gets called before matching any explicit routes or implicit shadow routes.


### PR DESCRIPTION
Pretty much every HTTP client nowadays (and certainly every client we support)
can support PUT and DELETE requests, and this method invocation is changing
with Express 4. Remove the `_method` hack.
