### PR TITLE
Point at Shyp's fork of sails-generate

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -366,13 +366,23 @@
       }
     },
     "sails-generate": {
-      "version": "0.11.6",
+      "version": "1.0.0",
+      "resolved": "git+https://github.com/Shyp/sails-generate.git#6275c419f1e0dde8f68f63357acfd0233f4d57c7",
       "dependencies": {
+        "async": {
+          "version": "0.7.0"
+        },
         "sails-generate-new": {
-          "version": "0.10.18"
+          "version": "0.10.18",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10"
+            }
+          }
         },
         "sails-generate-backend": {
-          "version": "0.11.3"
+          "version": "1.0.0",
+          "resolved": "git://github.com/Shyp/sails-generate-backend.git#366f0002bc841259089eeb76768f4383529732bf"
         },
         "sails-generate-frontend": {
           "version": "0.10.20"
@@ -381,7 +391,12 @@
           "version": "0.10.10"
         },
         "sails-generate-api": {
-          "version": "0.10.0"
+          "version": "0.10.0",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10"
+            }
+          }
         },
         "sails-generate-model": {
           "version": "0.10.9",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "reportback": "0.1.8",
     "sails-build-dictionary": "0.10.1",
     "sails-disk": "0.10.8",
-    "sails-generate": "0.11.6",
+    "sails-generate": "git+https://github.com/Shyp/sails-generate.git#v1.0.0",
     "sails-stringfile": "0.3.2",
     "sails-util": "0.10.4",
     "semver": "2.2.1",

--- a/test/integration/fixtures/sampleapp/api/policies/fake_auth.js
+++ b/test/integration/fixtures/sampleapp/api/policies/fake_auth.js
@@ -5,6 +5,6 @@
  */
 
 module.exports = function(req, res, next) {
-  req.session.authenticated = true;
+  req.authenticated = true;
   next();
 };


### PR DESCRIPTION
The Shyp fork changes req.session.authenticated to req.authenticated in
the sessionAuth example policy. Updates the one fake_auth.js policy in the
Sails tests that depends on it. Also removes any mention of CSRF, sockets or
sessions, and the associated configs.

Diffs:
- https://github.com/balderdashy/sails-generate-backend/compare/v0.11.3...Shyp:v1.0.0
- https://github.com/balderdashy/sails-generate/compare/v0.11.6...Shyp:v1.0.0
