### PR TITLE
Remove the favicon middleware

### DIFF
--- a/lib/hooks/http/index.js
+++ b/lib/hooks/http/index.js
@@ -62,7 +62,6 @@ module.exports = function(sails) {
               '$custom',
               'router',
               'www',
-              'favicon',
               '404',
               '500'
             ],

--- a/lib/hooks/http/middleware/defaults.js
+++ b/lib/hooks/http/middleware/defaults.js
@@ -35,8 +35,6 @@ module.exports = function(sails, app) {
       return flatFileMiddleware;
     })(),
 
-    favicon: express.favicon(),
-
     /**
      * Track request start time as soon as possible
      *
@@ -160,7 +158,7 @@ module.exports = function(sails, app) {
     },
 
     // 404 and 500 middleware should be attached at the very end
-    // (after `router`, `www`, and `favicon`)
+    // (after `router`, and `www`)
     404: function handleUnmatchedRequest(req, res, next) {
 
       // Explicitly ignore error arg to avoid inadvertently


### PR DESCRIPTION
Express 4 relies on serve-favicon version 2.0.0, which requires a default
favicon; Sails doesn't have one in the repo, and it doesn't make sense for us
anyway. We serve the favicon from the filesystem, browsers rarely have a need
to navigate to api.shyp.com, and if we felt we needed a more "scalable" favicon
serving mechanism, we could easily take the dependency in the Shyp API, not
here.
