### PR TITLE
Remove default X-Powered-By header

### DIFF
--- a/lib/hooks/http/index.js
+++ b/lib/hooks/http/index.js
@@ -58,7 +58,6 @@ module.exports = function(sails) {
               'bodyParser',
               'handleBodyParserError',
               'compress',
-              'poweredBy',
               '$custom',
               'router',
               'www',

--- a/lib/hooks/http/middleware/defaults.js
+++ b/lib/hooks/http/middleware/defaults.js
@@ -151,12 +151,6 @@ module.exports = function(sails, app) {
     // gets called before matching any explicit routes or implicit shadow routes.
     router: app.router,
 
-    // Add powered-by Sails header
-    poweredBy: function xPoweredBy(req, res, next) {
-      res.header('X-Powered-By', 'Sails <sailsjs.org>');
-      next();
-    },
-
     // 404 and 500 middleware should be attached at the very end
     // (after `router`, and `www`)
     404: function handleUnmatchedRequest(req, res, next) {


### PR DESCRIPTION
We don't want to reveal that we're using Sails, or which version we're using.
