### PR TITLE
Upgrade Waterline to v3.2.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -799,8 +799,8 @@
       }
     },
     "waterline": {
-      "version": "2.0.0",
-      "resolved": "git+https://github.com/Shyp/waterline.git#5ce7083fab5e5478f112cca168d9a2ad75796889",
+      "version": "3.2.0",
+      "resolved": "git+https://github.com/Shyp/waterline.git#0bc98df87356e5fab1f6c68edeb94b861596ee17",
       "dependencies": {
         "async": {
           "version": "0.9.0"
@@ -812,8 +812,8 @@
           "version": "0.1.7"
         },
         "lusitania": {
-          "version": "1.0.0",
-          "resolved": "git+https://github.com/Shyp/lusitania.git#38a3f194ae410b1ddcfebc854c000aa8e881b234",
+          "version": "2.2.0",
+          "resolved": "git+https://github.com/Shyp/lusitania.git#98ca16abd38c9b6b861b13667693c9058b41545c",
           "dependencies": {
             "validator": {
               "version": "3.22.2"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sails-util": "0.10.4",
     "semver": "2.2.1",
     "skipper": "0.5.5",
-    "waterline": "git+https://github.com/Shyp/waterline.git#v2.0.0"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v3.2.0"
   },
   "devDependencies": {
     "benchmark": "1.0.0",


### PR DESCRIPTION
This pulls in additional (better) changes to the validation error formatting,
based on testing against the Shyp API. Also pulls in a change to clone data
before sending it to the database for INSERT/UPDATE queries.

Furthermore, there's a small change to avoid `SET`ting a primary key when
calling `.save()` on a record - only update the other fields.

We'll need to test this in the Shyp API and probably make some changes in the
API based on it.

Diff: https://github.com/Shyp/waterline/compare/v2.0.0...v3.2.0
