### PR TITLE
Upgrade waterline to v3.3.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -799,8 +799,8 @@
       }
     },
     "waterline": {
-      "version": "3.2.0",
-      "resolved": "git+https://github.com/Shyp/waterline.git#0bc98df87356e5fab1f6c68edeb94b861596ee17",
+      "version": "3.3.0",
+      "resolved": "git+https://github.com/Shyp/waterline.git#9038c1227f4cb78691940a453165e74b9546ee53",
       "dependencies": {
         "async": {
           "version": "0.9.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sails-util": "0.10.4",
     "semver": "2.2.1",
     "skipper": "0.5.5",
-    "waterline": "git+https://github.com/Shyp/waterline.git#v3.2.0"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v3.3.0"
   },
   "devDependencies": {
     "benchmark": "1.0.0",


### PR DESCRIPTION
This change makes waterline.WLError inherit from the Javascript Error object,
which makes it catchable via (instanceof Error) checks.

Diff: https://github.com/Shyp/waterline/compare/v3.2.0...v3.3.0
