### PR TITLE
Bump Waterline to v3.4.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -799,8 +799,8 @@
       }
     },
     "waterline": {
-      "version": "3.3.0",
-      "resolved": "git+https://github.com/Shyp/waterline.git#9038c1227f4cb78691940a453165e74b9546ee53",
+      "version": "3.4.0",
+      "resolved": "git+https://github.com/Shyp/waterline.git#6c7f70243b3fa0bc53253ff785f335620f0d2efc",
       "dependencies": {
         "async": {
           "version": "0.9.0"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sails-util": "0.10.4",
     "semver": "2.2.1",
     "skipper": "0.5.5",
-    "waterline": "git+https://github.com/Shyp/waterline.git#v3.3.0"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v3.4.0"
   },
   "devDependencies": {
     "benchmark": "1.0.0",


### PR DESCRIPTION
This change passes through the originalError property when creating
a WLValidationError - we use it to figure out what to do when there's
a constraint failure.
