### PR TITLE
Don't throw error in CORS hook

### DIFF
--- a/lib/hooks/cors/index.js
+++ b/lib/hooks/cors/index.js
@@ -1,36 +1,35 @@
 module.exports = function(sails) {
 
-	/**
-	 * Module dependencies.
-	 */
+  /*
+   * Module dependencies.
+   */
 
-	var _ = require('lodash'),
-		util = require('sails-util'),
-		Hook = require('../../index');
+  var _ = require('lodash'),
+    util = require('sails-util'),
+    Hook = require('../../index');
 
 
-	/**
-	 * Expose hook definition
-	 */
-
-	return {
+  /*
+   * Expose hook definition
+   */
+  return {
 
     SECURITY_LEVEL_NORMAL: 0,
     SECURITY_LEVEL_HIGH: 1,
     SECURITY_LEVEL_VERYHIGH: 2,
 
-		defaults: {
-			cors: {
-				origin: '*',
-				credentials: true,
-				methods: 'GET, POST, PUT, DELETE, OPTIONS, HEAD',
-				headers: 'content-type',
+    defaults: {
+      cors: {
+        origin: '*',
+        credentials: true,
+        methods: 'GET, POST, PUT, DELETE, OPTIONS, HEAD',
+        headers: 'content-type',
         securityLevel: 0,
-			}
-		},
+      }
+    },
 
 
-		initialize: function(cb) {
+    initialize: function(cb) {
 
 			sails.on('router:before', function () {
 
@@ -134,10 +133,10 @@ module.exports = function(sails) {
 
 	function sendHeaders(_routeCorsConfig, isOptionsRoute) {
 
-		if (!_routeCorsConfig) {
-			_routeCorsConfig = {};
-		}
-		var _sendHeaders = function(req, res, next) {
+    if (!_routeCorsConfig) {
+      _routeCorsConfig = {};
+    }
+    var _sendHeaders = function(req, res, next) {
       var routeCorsConfig;
       // If this is an options route handler, pull the config to use based on the method
       // that would be used in the follow-on request
@@ -152,6 +151,11 @@ module.exports = function(sails) {
       else {
         routeCorsConfig = _routeCorsConfig;
       }
+
+      if (typeof routeCorsConfig === 'undefined') {
+        routeCorsConfig = {};
+      }
+
       // If we have an origin header...
 			if (req.headers && req.headers.origin) {
 

--- a/test/integration/router.specifiedRoutes.test.js
+++ b/test/integration/router.specifiedRoutes.test.js
@@ -41,6 +41,36 @@ describe('router :: ', function() {
 			appHelper.teardown();
 		});
 
+    describe('an options request', function() {
+      before(function() {
+        httpHelper.writeRoutes({
+          '/*': {
+            cors: true,
+          },
+          '/testRoute': {
+            controller: 'test',
+            action: 'verb',
+          },
+        });
+      });
+
+      it('should respond to OPTIONS requests', function(done) {
+        httpHelper.testRoute('options', {
+          url: 'testRoute',
+          headers: {
+            'Access-Control-Request-Method': 'post',
+            Origin: 'https://foo.shyp.com'
+          },
+        }, function(err, response, body) {
+          assert.equal(response.statusCode, 200);
+          assert.equal(response.body, 'GET,HEAD,PUT,POST,DELETE,PATCH');
+          assert.equal(response.headers.allow, 'GET,HEAD,PUT,POST,DELETE,PATCH');
+          assert.equal(response.headers['access-control-allow-origin'], 'https://foo.shyp.com');
+          done();
+        });
+      });
+    });
+
 		describe('with an unspecified http method', function() {
 
 			before(function() {
@@ -53,7 +83,6 @@ describe('router :: ', function() {
 			});
 
 			it('should respond to get requests', function(done) {
-
 
 				httpHelper.testRoute('get', 'testRoute', function(err, response) {
 					if (err) done(new Error(err));


### PR DESCRIPTION
Previously preflight requests would cause a TypeError in cors/index.js - see
https://github.com/balderdashy/sails/issues/3662 for more information on how
this occurs.

Fixes the error by converting any `undefined` values to a dictionary before
continuing processing- it's not perfect but it solves the problem.
