### PR TITLE
Bump Waterline to v3.5.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -906,8 +906,8 @@
       }
     },
     "waterline": {
-      "version": "3.4.0",
-      "resolved": "git+https://github.com/Shyp/waterline.git#6c7f70243b3fa0bc53253ff785f335620f0d2efc",
+      "version": "3.5.0",
+      "resolved": "git+https://github.com/Shyp/waterline.git#dc4ee6921f6c238227cd278a9a19cb4985a58f28",
       "dependencies": {
         "async": {
           "version": "0.9.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "sails-util": "0.10.4",
     "semver": "2.2.1",
     "skipper": "0.5.5",
-    "waterline": "git+https://github.com/Shyp/waterline.git#v3.4.0"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v3.5.0"
   },
   "devDependencies": {
     "benchmark": "1.0.0",


### PR DESCRIPTION
This version of Waterline adds support for debugging error construction, which
we need because our stack is throwing errors that we don't know much about.

Diff: https://github.com/shyp/waterline/compare/v3.4.0...v3.5.0
