### PR TITLE
Remove controller hook dependency on blueprints

### DIFF
--- a/lib/hooks/controllers/onRoute.js
+++ b/lib/hooks/controllers/onRoute.js
@@ -172,7 +172,7 @@ module.exports = function (sails) {
 
       // Mix in the relevant blueprint config
       options = _.defaults(options, {
-        populate: sails.config.blueprints.populate,
+        populate: false,
         defaultLimit: sails.config.blueprints.defaultLimit
       });
 
@@ -243,4 +243,3 @@ module.exports = function (sails) {
 	}
 
 };
-


### PR DESCRIPTION
There's probably more that we can rip out here related to Blueprints, but those
changes are tougher. This one crashes unless you define a blueprints config,
even if you don't have blueprints enabled.
