### PR TITLE
Update Waterline to v3.7.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -537,8 +537,8 @@
       "version": "2.2.1"
     },
     "waterline": {
-      "version": "3.5.0",
-      "resolved": "git+https://github.com/Shyp/waterline.git#dc4ee6921f6c238227cd278a9a19cb4985a58f28",
+      "version": "3.7.0",
+      "resolved": "git+https://github.com/Shyp/waterline.git#9658b325216e3d3b3b03ba2f5d5ebb80d8727dd7",
       "dependencies": {
         "async": {
           "version": "0.9.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "sails-stringfile": "0.3.2",
     "sails-util": "0.10.4",
     "semver": "2.2.1",
-    "waterline": "git+https://github.com/Shyp/waterline.git#v3.5.0"
+    "waterline": "git+https://github.com/Shyp/waterline.git#v3.7.0"
   },
   "devDependencies": {
     "benchmark": "1.0.0",


### PR DESCRIPTION
Updates Waterline to v3.7.0, which has support for coercing primary keys
that are "uuid" type.

Also includes v3.6.0, which consists of test environment changes.

Diff: [Shyp/waterline@v3.5.0...v3.7.0](https://github.com/Shyp/waterline/compare/v3.5.0...v3.7.0)
